### PR TITLE
The encode method now supports a double value

### DIFF
--- a/lib/src/objectdb_base.dart
+++ b/lib/src/objectdb_base.dart
@@ -434,7 +434,7 @@ class ObjectDB {
     if (value is Map) {
       return this._encode(value);
     }
-    if (value is String || value is int || value is bool || value is List) {
+    if (value is String || value is int || value is double || value is bool || value is List) {
       return value;
     }
     if (value is RegExp) {


### PR DESCRIPTION
I think this was just a mistake, because everything is working well.